### PR TITLE
Revert "use the raspbian src instead of debian" (PR #24) …

### DIFF
--- a/overlay/usr/sbin/gitlab-reconfigure
+++ b/overlay/usr/sbin/gitlab-reconfigure
@@ -2,4 +2,3 @@
 sed -i "s/external_url '.*'/external_url 'http:\/\/$(/usr/local/bin/oc-metadata --cached ID).pub.cloud.scaleway.com'/g" /etc/gitlab/gitlab.rb
 gitlab-ctl reconfigure
 sed -i 's/.*gitlab-reconfigure.*//g' /etc/rc.local
-sed -i 's/debian/raspbian/g' /etc/apt/sources.list.d/gitlab_raspberry-pi2.list


### PR DESCRIPTION
… in favour of issue #28

This reverts commit 767a44f54509a5c59dddf2a4f489d80fa3791494.